### PR TITLE
Split interface depending on container / standalone operation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,7 @@ ENV MNI_PERL5LIB /opt/freesurfer/mni/lib/perl5/5.8.5
 # MRtrix3 setup
 ENV CXX=/usr/bin/g++-5
 # Note: Current commit being checked out includes various fixes that have been necessary to get test data working; eventually it will instead point to a release tag that includes these updates
-RUN git clone https://github.com/MRtrix3/mrtrix3.git mrtrix3 && cd mrtrix3 && git checkout 3d0e89fc && python configure -nogui && NUMBER_OF_PROCESSORS=1 python build && git describe --tags > /mrtrix3_version
+RUN git clone https://github.com/MRtrix3/mrtrix3.git mrtrix3 && cd mrtrix3 && git checkout e773629 && python configure -nogui && NUMBER_OF_PROCESSORS=1 python build && git describe --tags > /mrtrix3_version
 #RUN echo $'FailOnWarn: 1\n' > /etc/mrtrix.conf
 
 # Setup environment variables

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,7 @@ ENV MNI_PERL5LIB /opt/freesurfer/mni/lib/perl5/5.8.5
 # MRtrix3 setup
 ENV CXX=/usr/bin/g++-5
 # Note: Current commit being checked out includes various fixes that have been necessary to get test data working; eventually it will instead point to a release tag that includes these updates
-RUN git clone https://github.com/MRtrix3/mrtrix3.git mrtrix3 && cd mrtrix3 && git checkout 999cfdd && python configure -nogui && NUMBER_OF_PROCESSORS=1 python build && git describe --tags > /mrtrix3_version
+RUN git clone https://github.com/MRtrix3/mrtrix3.git mrtrix3 && cd mrtrix3 && git checkout 3d0e89fc && python configure -nogui && NUMBER_OF_PROCESSORS=1 python build && git describe --tags > /mrtrix3_version
 #RUN echo $'FailOnWarn: 1\n' > /etc/mrtrix.conf
 
 # Setup environment variables

--- a/README.md
+++ b/README.md
@@ -38,10 +38,6 @@ Yeh, C.H.; Smith, R.E.; Liang, X.; Calamante, F.; Connelly, A. Correction for di
 Zhang, Y.; Brady, M. & Smith, S. Segmentation of brain MR images through a hidden Markov random field model and the expectation-maximization algorithm. IEEE Transactions on Medical Imaging, 2001, 20, 45-57
 ```
 
-### Usage
-
-Command-line usage of the processing script `run.py` is as follows (also accessible by running the script without any command-line options):
-
 ## Synopsis
 
 Generate structural connectomes based on diffusion-weighted and T1-weighted image data using state-of-the-art reconstruction tools, particularly those provided in MRtrix3
@@ -58,39 +54,23 @@ Generate structural connectomes based on diffusion-weighted and T1-weighted imag
 
 #### Options that are relevant to participant-level analysis
 
-+ **-atlas_path/--atlas_path**<br>The path to search for an atlas parcellation (useful if the script is executed outside of the BIDS App container
++ **--parcellation**<br>The choice of connectome parcellation scheme (compulsory for participant-level analysis). Options are: aal, aal2, fs_2005, fs_2009
 
-+ **-parcellation/--parcellation**<br>The choice of connectome parcellation scheme (compulsory for participant-level analysis). Options are: aal, aal2, fs_2005, fs_2009
++ **--preprocessed**<br>Indicate that the subject DWI data have been preprocessed, and hence initial image processing steps will be skipped (also useful for testing)
 
-+ **-preprocessed/--preprocessed**<br>Indicate that the subject DWI data have been preprocessed, and hence initial image processing steps will be skipped (also useful for testing)
-
-+ **-streamlines/--streamlines**<br>The number of streamlines to generate for each subject
++ **--streamlines**<br>The number of streamlines to generate for each subject
 
 #### Options specific to the batch processing of subject data
 
-+ **-participant_label/--participant_label**<br>The label(s) of the participant(s) that should be analyzed. The label(s) correspond(s) to sub-<participant_label> from the BIDS spec (so it does _not_ include "sub-"). If this parameter is not provided, all subjects will be analyzed sequentially. Multiple participants can be specified with a space-separated list.
++ **--participant_label**<br>The label(s) of the participant(s) that should be analyzed. The label(s) correspond(s) to sub-<participant_label> from the BIDS spec (so it does _not_ include "sub-"). If this parameter is not provided, all subjects will be analyzed sequentially. Multiple participants can be specified with a space-separated list.
 
 #### Standard options
 
-+ **-continue <TempDir> <LastFile>**<br>Continue the script from a previous execution; must provide the temporary directory path, and the name of the last successfully-generated file
++ **-d/--debug**<br>In the event of encountering an issue with the script, re-run with this flag set to provide more useful information to the developer
 
-+ **-force**<br>Force overwrite of output files if pre-existing
++ **-h/--help**<br>Display help information for the script
 
-+ **-help/--help**<br>Display help information for the script
-
-+ **-nocleanup**<br>Do not delete temporary files during script, or temporary directory at script completion
-
-+ **-nthreads/--n_cpus number**<br>Use this number of threads in MRtrix multi-threaded applications (0 disables multi-threading)
-
-+ **-tempdir /path/to/tmp/**<br>Manually specify the path in which to generate the temporary directory
-
-+ **-quiet**<br>Suppress all console output during script execution
-
-+ **-info**<br>Display additional information and progress for every command invoked
-
-+ **-debug**<br>Display additional debugging information over and above the output of -info
-
-#### optional arguments
++ **-n/--n_cpus number**<br>Use this number of threads in MRtrix3 multi-threaded applications (0 disables multi-threading)
 
 + **-v/--version**<br>show program's version number and exit
 
@@ -109,6 +89,8 @@ but WITHOUT ANY WARRANTY; without even the implied warranty
 of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 
 For more details, see http://www.mrtrix.org/.
+
+
 
 
 
@@ -142,3 +124,5 @@ $ docker run -i --rm \
 ```
 
 If you wish to run this script on a computing cluster, we recommend the use of [Singularity](http://singularity.lbl.gov/). Although built for Docker, this container can be converted using the [`docker2singularity` tool](https://github.com/singularityware/docker2singularity).
+
+The script ``run.py`` can additionally be used *outside* of this Docker container, as a stand-alone Python script build against the *MRtrix3* Python libraries. Using the script in this way requires setting the ``PYTHONPATH`` environment variable to include the path to the *MRtrix3* ``lib/`` directory where it is installed on your local system, as described [here](http://mrtrix.readthedocs.io/en/latest/troubleshooting/FAQ.html#making-use-of-python-scripts-library). When used in this way, the command-line interface of the script will be more consistent with the rest of *MRtrix3*.

--- a/circle.yml
+++ b/circle.yml
@@ -25,9 +25,9 @@ test:
     # print version
     - docker run -ti --rm --read-only -v /tmp:/tmp -v /var/tmp:/var/tmp -v ${HOME}/data:/bids_dataset bids/${CIRCLE_PROJECT_REPONAME,,} --version
     # participant level tests for single session dataset
-    - docker run -ti --rm --read-only -v /tmp:/tmp -v /var/tmp:/var/tmp -v ${HOME}/data:/bids_dataset -v ${HOME}/outputs:/outputs bids/${CIRCLE_PROJECT_REPONAME,,} /bids_dataset /outputs participant --participant_label 01 -parc aal -streamlines 100000 -preprocessed :
+    - docker run -ti --rm --read-only -v /tmp:/tmp -v /var/tmp:/var/tmp -v ${HOME}/data:/bids_dataset -v ${HOME}/outputs:/outputs bids/${CIRCLE_PROJECT_REPONAME,,} /bids_dataset /outputs participant --participant_label 01 --parcellation aal --streamlines 100000 --preprocessed :
         timeout: 21600
-    - docker run -ti --rm --read-only -v /tmp:/tmp -v /var/tmp:/var/tmp -v ${HOME}/data:/bids_dataset -v ${HOME}/outputs:/outputs bids/${CIRCLE_PROJECT_REPONAME,,} /bids_dataset /outputs participant --participant_label 02 -parc aal -streamlines 100000 -preprocessed :
+    - docker run -ti --rm --read-only -v /tmp:/tmp -v /var/tmp:/var/tmp -v ${HOME}/data:/bids_dataset -v ${HOME}/outputs:/outputs bids/${CIRCLE_PROJECT_REPONAME,,} /bids_dataset /outputs participant --participant_label 02 --parcellation aal --streamlines 100000 --preprocessed :
         timeout: 21600
     # group level test for single session dataset
     - docker run -ti --rm --read-only -v /tmp:/tmp -v /var/tmp:/var/tmp -v ${HOME}/data:/bids_dataset -v ${HOME}/outputs:/outputs bids/${CIRCLE_PROJECT_REPONAME,,} /bids_dataset /outputs group :

--- a/run.py
+++ b/run.py
@@ -7,7 +7,6 @@ from mrtrix3 import app, file, fsl, image, path, run
 
 is_container = os.path.exists('/version')
 __version__ = 'BIDS-App \'MRtrix3_connectome\' version {}'.format(open('/version').read()) if is_container else 'BIDS-App \'MRtrix3_connectome\' standalone'
-is_container = True
 option_prefix = '--' if is_container else '-'
 
 
@@ -238,7 +237,7 @@ def runSubject(bids_dir, label, output_prefix):
 
     # If fmap images and DWIs have been concatenated, now is the time to split them back apart
     dwipreproc_input = 'dwi_unring.mif' if unring_cmd else 'dwi_denoised.mif'
-  
+
     if fmap_num_volumes:
       cat_input = 'dwi_unring.mif' if unring_cmd else 'dwi_denoised.mif'
       dwipreproc_se_epi = 'se_epi.mif'
@@ -662,7 +661,7 @@ participant_options.add_argument(option_prefix + 'streamlines', type=int, help='
 
 app.parse()
 
-  
+
 
 if app.isWindows():
   app.error('Script cannot be run on Windows due to FSL dependency')


### PR DESCRIPTION
Pushing these changes in order to fix the error reported in #15.

The command-line options available within the script will depend on whether the script is being run from within the Docker container environment, or as a stand-alone script against the *MRtrix3* Python libraries. In the former, only minimal command-line options are provided, some of which are consistent with other BIDS Apps /OpenNeuro, and have a double-dash prefix. In the latter, the interface remains more consistent with other *MRtrix3* Python scripts, including all of the standard command-line options available in these scripts, and options use a single-dash prefix.

Also includes some small tweaks that I found while solving #15.

Addresses some of the points made in #13.

Closes #15.