### PR TITLE
Tag 0.2.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,13 +66,14 @@ ENV MNI_PERL5LIB /opt/freesurfer/mni/lib/perl5/5.8.5
 # MRtrix3 setup
 ENV CXX=/usr/bin/g++-5
 # Note: Current commit being checked out includes various fixes that have been necessary to get test data working; eventually it will instead point to a release tag that includes these updates
-RUN git clone https://github.com/MRtrix3/mrtrix3.git mrtrix3 && cd mrtrix3 && git checkout 6189e4e && python configure -nogui && NUMBER_OF_PROCESSORS=1 python build && git describe --tags > /mrtrix3_version
+RUN git clone https://github.com/MRtrix3/mrtrix3.git mrtrix3 && cd mrtrix3 && git checkout 6b9fade && python configure -nogui && NUMBER_OF_PROCESSORS=1 python build && git describe --tags > /mrtrix3_version
 #RUN echo $'FailOnWarn: 1\n' > /etc/mrtrix.conf
 
 # Setup environment variables
 ENV FSLDIR=/usr/share/fsl/5.0
 ENV FSLMULTIFILEQUIT=TRUE
-ENV FSLOUTPUTTYPE=NIFTI
+# Would prefer NIFTI, but fsl-5.0-core can ignore this field, writing .nii.gz regardless, in which case MRtrix3 gets stuck looking for .nii
+ENV FSLOUTPUTTYPE=NIFTI_GZ
 ENV LD_LIBRARY_PATH=/usr/lib/fsl/5.0
 ENV PATH=/opt/freesurfer/bin:/opt/freesurfer/mni/bin:/usr/lib/fsl/5.0:/usr/lib/ants:/mrtrix3/bin:/opt/reisert-unring-8e5eeba67a1d/fsl/:/opt/eddy:$PATH
 ENV PYTHONPATH=/mrtrix3/lib

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,7 +72,8 @@ RUN git clone https://github.com/MRtrix3/mrtrix3.git mrtrix3 && cd mrtrix3 && gi
 # Setup environment variables
 ENV FSLDIR=/usr/share/fsl/5.0
 ENV FSLMULTIFILEQUIT=TRUE
-ENV FSLOUTPUTTYPE=NIFTI
+# Note: Would prefer NIFTI, but need to stick to compressed for now due to FSL Ubuntu not honoring this variable. May be able to revert once fsl.checkFirst() is merged in.
+ENV FSLOUTPUTTYPE=NIFTI_GZ
 ENV LD_LIBRARY_PATH=/usr/lib/fsl/5.0
 ENV PATH=/opt/freesurfer/bin:/opt/freesurfer/mni/bin:/usr/lib/fsl/5.0:/usr/lib/ants:/mrtrix3/bin:/opt/reisert-unring-8e5eeba67a1d/fsl/:/opt/eddy:$PATH
 ENV PYTHONPATH=/mrtrix3/lib

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,8 +72,7 @@ RUN git clone https://github.com/MRtrix3/mrtrix3.git mrtrix3 && cd mrtrix3 && gi
 # Setup environment variables
 ENV FSLDIR=/usr/share/fsl/5.0
 ENV FSLMULTIFILEQUIT=TRUE
-# Would prefer NIFTI, but fsl-5.0-core can ignore this field, writing .nii.gz regardless, in which case MRtrix3 gets stuck looking for .nii
-ENV FSLOUTPUTTYPE=NIFTI_GZ
+ENV FSLOUTPUTTYPE=NIFTI
 ENV LD_LIBRARY_PATH=/usr/lib/fsl/5.0
 ENV PATH=/opt/freesurfer/bin:/opt/freesurfer/mni/bin:/usr/lib/fsl/5.0:/usr/lib/ants:/mrtrix3/bin:/opt/reisert-unring-8e5eeba67a1d/fsl/:/opt/eddy:$PATH
 ENV PYTHONPATH=/mrtrix3/lib

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,7 @@ ENV MNI_PERL5LIB /opt/freesurfer/mni/lib/perl5/5.8.5
 # MRtrix3 setup
 ENV CXX=/usr/bin/g++-5
 # Note: Current commit being checked out includes various fixes that have been necessary to get test data working; eventually it will instead point to a release tag that includes these updates
-RUN git clone https://github.com/MRtrix3/mrtrix3.git mrtrix3 && cd mrtrix3 && git checkout 6b9fade && python configure -nogui && NUMBER_OF_PROCESSORS=1 python build && git describe --tags > /mrtrix3_version
+RUN git clone https://github.com/MRtrix3/mrtrix3.git mrtrix3 && cd mrtrix3 && git checkout 54faeb61 && python configure -nogui && NUMBER_OF_PROCESSORS=1 python build && git describe --tags > /mrtrix3_version
 #RUN echo $'FailOnWarn: 1\n' > /etc/mrtrix.conf
 
 # Setup environment variables


### PR DESCRIPTION
Fix to reflect renaming of MRtrix3 `mrinfo` option `-json_export` being renamed to `-json_keyval` - as reported [here](https://github.com/BIDS-Apps/MRtrix3_connectome/pull/18#issuecomment-330144488).

Had to make various fixes to *MRtrix3* to get the script running to completion with a FreeSurfer parcellation. Most of these are changes to the Python scripting library that had not yet been adequately tested in isolation. These can be found in *MRtrix3* pull request [#1049](https://github.com/MRtrix3/mrtrix3/pull/1049).

Also changed FSL to use compressed NIfTI format. Although the un-compressed format would be preferable in this context (since if NIfTI files are only generated for compatibility of intermediate files with other software packages, compressing / uncompressing is a waste), the particular version of FSL distributed for Ubuntu 14.04 ignores the `FSLOUTPUTTYPE` environment variable; so this change is actually to make sure that *MRtrix3* can find the files generated by FSL.

Additional items now listed in #3 and #19.