### PR TITLE
Split analysis level outputs

### DIFF
--- a/mrtrix3_connectome.py
+++ b/mrtrix3_connectome.py
@@ -1951,6 +1951,12 @@ def run_participant(bids_dir, session, shared,
                                    'dwi',
                                    '*_dwi.nii*')
         in_dwi_image_list = glob.glob(in_dwi_path)
+        if not in_dwi_image_list:
+            raise MRtrixError('No DWIs found for session "'
+                              + session_label
+                              + '" loaded from "'
+                              + import_path
+                              + '"')
         if len(in_dwi_image_list) > 1:
             raise MRtrixError('To run participant-level analysis, '
                               + 'input directory should contain only one '

--- a/mrtrix3_connectome.py
+++ b/mrtrix3_connectome.py
@@ -3915,7 +3915,7 @@ def execute(): #pylint: disable=unused-variable
         output_app_path = output_dirname
     # Basename of output path is unknown
     else:
-        output_app_path = os.path.join(output_abspath, 'mrtrix3_connectome')
+        output_app_path = os.path.join(output_abspath, 'MRtrix3_connectome')
     if not os.path.isdir(output_app_path):
         run.function(os.makedirs, output_app_path)
 

--- a/mrtrix3_connectome.py
+++ b/mrtrix3_connectome.py
@@ -1806,6 +1806,7 @@ def run_participant(bids_dir, session, shared,
                  'already exists; all contents will be erased when this '
                  'execution completes')
 
+
     # Check paths of individual output files before script completion
     #   by building a database of what files are to be written to output
     parc_string = '_desc-' + shared.parcellation
@@ -1946,32 +1947,27 @@ def run_participant(bids_dir, session, shared,
                                     session_label
                                     + '_space-superres_tdi.nii.gz'))
 
+
     def do_import(import_path):
-        in_dwi_path = os.path.join(import_path,
+        in_dwi_path = os.path.join(os.path.join(import_path, *session),
                                    'dwi',
                                    '*_dwi.nii*')
         in_dwi_image_list = glob.glob(in_dwi_path)
         if not in_dwi_image_list:
             raise MRtrixError('No DWIs found for session "'
                               + session_label
-                              + '" loaded from "'
-                              + import_path
                               + '"')
         if len(in_dwi_image_list) > 1:
             raise MRtrixError('To run participant-level analysis, '
                               + 'input directory should contain only one '
                               + 'DWI image file; session "'
                               + session_label
-                              + '" loaded from "'
-                              + import_path
                               + '" contains '
                               + str(len(in_dwi_image_list)))
         in_dwi_path = in_dwi_image_list[0]
         if not '_desc-preproc_' in in_dwi_path:
             raise MRtrixError('Input DWI image "'
                               + in_dwi_path
-                              + '" loaded from "'
-                              + import_path
                               + '" not flagged as pre-processed data')
         in_dwi_path_prefix = in_dwi_path.split(os.extsep)[0]
         # Don't look for bvec / bval in a lower directory in this case
@@ -2058,11 +2054,11 @@ def run_participant(bids_dir, session, shared,
         except MRtrixError as e_fromoutput:
             err = 'Unable to import requisite pre-processed data from ' \
                   'either specified input directory or MRtrix3_connectome ' \
-                  'output directory\n\n'
-            err += 'Error when loading from "' + bids_dir + '":\n'
+                  'output directory\n'
+            err += 'Error when attempting load from "' + bids_dir + '":\n'
             err += str(e_frombids) + '\n'
-            err += 'Error when loading from "' + output_app_dir + '":\n'
-            err += str(e_fromoutput) + '\n'
+            err += 'Error when attempting load from "' + output_app_dir + '":\n'
+            err += str(e_fromoutput)
             raise MRtrixError(err)
 
 

--- a/mrtrix3_connectome.py
+++ b/mrtrix3_connectome.py
@@ -1806,8 +1806,6 @@ def run_participant(bids_dir, session, shared,
                  'already exists; all contents will be erased when this '
                  'execution completes')
 
-    app.make_scratch_dir()
-
     # Check paths of individual output files before script completion
     #   by building a database of what files are to be written to output
     parc_string = '_desc-' + shared.parcellation
@@ -1948,13 +1946,6 @@ def run_participant(bids_dir, session, shared,
                                     session_label
                                     + '_space-superres_tdi.nii.gz'))
 
-    subdirs_to_make = ['tractogram']
-    if shared.parcellation != 'none':
-        subdirs_to_make.insert(0, 'connectome')
-
-    app.make_scratch_dir()
-
-
     def do_import(import_path):
         in_dwi_path = os.path.join(import_path,
                                    'dwi',
@@ -2050,6 +2041,7 @@ def run_participant(bids_dir, session, shared,
     #   that the pre-processed data be utilised from some path other than
     #   "mrtrix3_connectome/preproc/"); if that doesn't work, we wipe the
     #   scratch directory and try again based on the latter
+    app.make_scratch_dir()
     try:
         do_import(bids_dir)
     except MRtrixError as e_frombids:
@@ -2664,13 +2656,14 @@ def run_participant(bids_dir, session, shared,
     # Prepare output path for writing
     app.console('Processing for session "' + session_label
                 + '" completed; writing results to output directory')
+    subdirs_to_make = ['anat', 'dwi', 'tractogram']
+    if shared.parcellation != 'none':
+        subdirs_to_make.insert(1, 'connectome')
     for subdir in subdirs_to_make:
         full_subdir_path = os.path.join(output_subdir, subdir)
         if os.path.exists(full_subdir_path):
             run.function(shutil.rmtree, full_subdir_path)
         run.function(os.makedirs, full_subdir_path)
-    if not os.path.isdir(os.path.join(output_subdir, 'anat')):
-        run.function(os.makedirs, os.path.join(output_subdir, 'anat'))
 
     # Generate a copy of the lookup table file:
     #   - Use the post-labelconvert file if it's used;

--- a/mrtrix3_connectome.py
+++ b/mrtrix3_connectome.py
@@ -2753,6 +2753,7 @@ GROUP_WARPS_DIR = 'warps'
 
 def run_group(bids_dir, output_verbosity, output_app_dir):
 
+    preproc_dir = os.path.join(output_app_dir, 'preproc')
     participant_dir = os.path.join(output_app_dir, 'participant')
     group_dir = os.path.join(output_app_dir, 'group')
 
@@ -2766,10 +2767,11 @@ def run_group(bids_dir, output_verbosity, output_app_dir):
     class SessionPaths(object):
         def __init__(self, session):
             session_label = '_'.join(session)
-            participant_root = os.path.join(group_dir, *session)
+            preproc_root = os.path.join(preproc_dir, *session)
+            participant_root = os.path.join(participant_dir, *session)
             group_root = os.path.join(group_dir, *session)
             # Get input DWI path here rather than in function
-            in_dwi_image_list = glob.glob(os.path.join(participant_root,
+            in_dwi_image_list = glob.glob(os.path.join(preproc_root,
                                                        'dwi',
                                                        '*_dwi.nii*'))
             if not in_dwi_image_list:
@@ -2838,11 +2840,16 @@ def run_group(bids_dir, output_verbosity, output_app_dir):
                 re.findall('(?<=_desc-)[a-zA-Z0-9]*',
                            os.path.basename(self.in_connectome))[0]
 
-            # Permissible for this to not exist
-            self.in_mask = os.path.join(participant_root,
+            # Permissible for this to not exist at either location
+            self.in_mask = os.path.join(preproc_root,
                                         'dwi',
                                         session_label
                                         + '_desc-brain_mask.nii.gz')
+            if not os.path.isfile(self.in_mask):
+                self.in_mask = os.path.join(preproc_root,
+                                            'dwi',
+                                            session_label
+                                            + '_desc-brain_mask.nii.gz')
 
             self.mu = matrix.load_vector(self.in_mu)[0]
             self.RF = matrix.load_matrix(self.in_rf)

--- a/mrtrix3_connectome.py
+++ b/mrtrix3_connectome.py
@@ -3245,6 +3245,7 @@ def get_sessions(root_dir, **kwargs):
         if 'anat' in subdir_list and 'dwi' in subdir_list:
             all_sessions.append(os.path.relpath(dir_name, start=root_dir))
             del subdir_list
+    all_sessions = sorted(all_sessions)
     app.debug(str(all_sessions))
 
     result = []

--- a/mrtrix3_connectome.py
+++ b/mrtrix3_connectome.py
@@ -2076,13 +2076,15 @@ def run_participant(bids_dir, session, shared,
                    os.path.join(output_subdir,
                                 'anat',
                                 session_label + '_desc-preproc_T1w.nii.gz'))
+    T1_json_data = {"SkullStripped": T1_is_premasked}
     T1_json_path = os.path.splitext(T1_image)[0] + '.json'
+    with open(T1_json_path, 'w') as T1_json_file:
+        json.dump(T1_json_data, T1_json_file)
     output_items[T1_json_path] = \
         OutputItem(False, 1, False, None,
                    os.path.join(output_subdir,
                                 'anat',
                                 session_label + '_desc-preproc_T1w.json'))
-    T1_json_data = {"SkullStripped": T1_is_premasked}
 
     # Before we can begin: Are there any data we require
     #   that were not imported from the output directory?
@@ -2114,7 +2116,7 @@ def run_participant(bids_dir, session, shared,
     #     bad masking
 
     app.console('Estimating '
-                + (' multi-tissue ODF images'
+                + ('multi-tissue ODF images'
                    if multishell
                    else 'Fibre Orientation Distribution image'))
     # TODO Update to use similar code to preproc?
@@ -2705,9 +2707,6 @@ def run_participant(bids_dir, session, shared,
                 run.function(shutil.copyfile,
                              scratch_file,
                              full_output_path)
-
-    with open(T1_json_path, 'w') as T1_json_file:
-        json.dump(T1_json_data, T1_json_file)
 
     # Manually wipe and zero the scratch directory
     #   (since we might be processing more than one subject)


### PR DESCRIPTION
Instead of attempting to converge the outputs of all three analysis levels into a single output directory, use a structure more faithful to the development of BIDS Derivatives:

- Outputs from the tool will always be in a directory named "MRtrix3_connectome".

- The three analysis levels will each create their own sub-directory of the above.

Note that this also includes a rename of the "`participant1`" and "`participant2`" analysis levels to "`preproc`" and "`participant`".

While it is possible to feed data from some other DWI pre-processing BIDS App into the "`participant`"-level processing by providing that BIDS Derivatives location as the "BIDS input", the same will not currently work for group-level analysis, due to the current mechanism of *b*=0 intensity normalisation.

Also includes the capability to run through group-level analysis with a single session.