### PR TITLE
participant: Modify ANTs MNI registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,12 +160,13 @@ et al., 2016; (IF USING EDDY_CUDA: Andersson et al., 2017)); and bias field corr
 deconvolution (Tournier et al., 2004; Jeurissen et al., 2014); probabilistic tractography
 (Tournier et al., 2010) utilizing Anatomically-Constrained Tractography (Smith et al.,
 2012) and dynamic seeding (Smith et al., 2015b); SIFT2 (Smith et al., 2015b); T1
-parcellation (((Avants et al., 2008 OR Andersson et al., 2010) AND (Tzourio-Mazoyer et al.,
-2002 OR Yeo et al., 2011 OR Craddock et al., 2012 OR Fan et al., 2016 OR (Zalesky et al.,
-2010 AND Perry et al., 2017))) OR (Dale et al., 1999 AND (Desikan et al., 2006 OR
-Destrieux et al., 2010 OR Glasser et al., 2016))); robust structural connectome
-construction Smith et al., 2015a; Yeh et al., 2016); inter-subject connection density
-normalisation (Smith et al., 2020).
+parcellation ((((Avants et al., 2008 AND Tustison et al., 2013) OR Andersson et al.,
+2010) AND (Tzourio-Mazoyer et al., 2002 OR Yeo et al., 2011 OR Craddock et al., 2012
+2011) OR Fan et al., 2016 OR (Zalesky et al., 2010 AND Perry et al., 2017))) OR
+2012) (Dale et al., 1999 AND (Desikan et al., 2006 OR Destrieux et al., 2010 OR
+2013) Glasser et al., 2016))); robust structural connectome construction (Smith et al.,
+2014) 2015a; Yeh et al., 2016); inter-subject connection density normalisation
+2015) (Smith et al., 2020).
 
 ```
 Smith, R. E.; Connelly, A. MRtrix3_connectome: A BIDS Application for quantitative structural connectome construction. In Proc OHBM, 2019, W610
@@ -197,6 +198,7 @@ Tournier, J.-D.; Calamante, F., Gadian, D.G. & Connelly, A. Direct estimation of
 Tournier, J.-D.; Calamante, F. & Connelly, A. Improved probabilistic streamlines tractography by 2nd order integration over fibre orientation distributions. Proceedings of the International Society for Magnetic Resonance in Medicine, 2010, 1670
 Tournier, J.-D.; Smith, R. E.; Raffelt, D. A.; Tabbara, R.; Dhollander, T.; Pietsch, M; Christiaens, D.; Jeurissen, B.; Y, C.-H.; Connelly, A. MRtrix3: A fast, flexible and open software framework for medical image processing and visualisation. NeuroImage, 2019, 202, 116137
 Tustison, N.; Avants, B.; Cook, P.; Zheng, Y.; Egan, A.; Yushkevich, P. & Gee, J. N4ITK: Improved N3 Bias Correction. IEEE Transactions on Medical Imaging, 2010, 29, 1310-1320
+Tustison, N.; Avants, B. Explicit B-spline regularization in diffeomorphic image registration. Frontiers in Neuroinformatics, 2013, 7, 39
 Tzourio-Mazoyer, N.; Landeau, B.; Papathanassiou, D.; Crivello, F.; Etard, O.; Delcroix, N.; Mazoyer, B. & Joliot, M. Automated Anatomical Labeling of activations in SPM using a Macroscopic Anatomical Parcellation of the MNI MRI single-subject brain. NeuroImage, 15(1), 273–289
 Veraart, J.; Novikov, D. S.; Christiaens, D.; Ades-aron, B.; Sijbers, J. & Fieremans, E. Denoising of diffusion MRI using random matrix theory. NeuroImage, 2016, 142, 394-406
 Yeh, C.-H.; Smith, R. E.; Liang, X.; Calamante, F. & Connelly, A. Correction for diffusion MRI fibre tracking biases: The consequences for structural connectomic metrics. NeuroImage, 2016, 142, 150-162

--- a/mrtrix3_connectome.py
+++ b/mrtrix3_connectome.py
@@ -2390,12 +2390,11 @@ def run_participant(bids_dir, session, shared,
 
             # Use ANTs SyN for registration to template
             # From Klein and Avants, Frontiers in Neuroinformatics 2013:
-            ants_prefix = 'template_to_t1'
+            ants_prefix = 'template_to_t1_'
             run.command('antsRegistration'
                         + ' --dimensionality 3'
                         + ' --output '
                         + ants_prefix
-                        + '.nii'
                         + ' --use-histogram-matching 1'
                         + ' --initial-moving-transform ['
                         + T1_histmatched_path
@@ -2446,7 +2445,7 @@ def run_participant(bids_dir, session, shared,
                         + ants_prefix
                         + '0GenericAffine.mat'
                         + ' --default-value 0')
-            app.cleanup(glob.glob(ants_prefix))
+            app.cleanup(glob.glob(ants_prefix + '*'))
 
         elif shared.template_registration_software == 'fsl':
 

--- a/mrtrix3_connectome.py
+++ b/mrtrix3_connectome.py
@@ -2391,7 +2391,7 @@ def run_participant(bids_dir, session, shared,
             # Use ANTs SyN for registration to template
             # From Klein and Avants, Frontiers in Neuroinformatics 2013:
             ants_prefix = 'template_to_t1'
-            run.command('ANTSRegistration'
+            run.command('antsRegistration'
                         + ' --dimensionality 3'
                         + ' --output '
                         + ants_prefix

--- a/mrtrix3_connectome.py
+++ b/mrtrix3_connectome.py
@@ -2406,7 +2406,7 @@ def run_participant(bids_dir, session, shared,
                         + ' --metric MI['
                         + T1_histmatched_path
                         + ','
-                        + shared.template_iamge_path
+                        + shared.template_image_path
                         + ',1,32,Regular,0.25]'
                         + ' --convergence 1000x500x250x100'
                         + ' --smoothing-sigmas 3x2x1x0'
@@ -2424,7 +2424,7 @@ def run_participant(bids_dir, session, shared,
                         + ' --metric CC['
                         + T1_histmatched_path
                         + ','
-                        + shared.template_iamge_path
+                        + shared.template_image_path
                         + ',1,4]'
                         + ' --convergence 100x70x50x20'
                         + ' --smoothing-sigmas 3x2x1x0'

--- a/mrtrix3_connectome.py
+++ b/mrtrix3_connectome.py
@@ -3957,6 +3957,17 @@ See the Mozilla Public License v. 2.0 for more details.''')
         'analysis, and N4 is used for either DWI or T1 bias field correction',
         is_external=True)
     cmdline.add_citation(
+        'Tustison, N.; Avants, B. '
+        'Explicit B-spline regularization in diffeomorphic image '
+        'registration. '
+        'Frontiers in Neuroinformatics, 2013, 7, 39',
+        condition='If performing participant-level analysis, '
+        + 'using ' + OPTION_PREFIX + 'parcellation [ aal, aal2, '
+        + 'brainnetome246mni, craddock200, craddock400, perry512, '
+        + 'yeo7mni or yeo17mni ], '
+        + 'and not using ' + OPTION_PREFIX + 'template_reg fsl',
+        is_external=True)
+    cmdline.add_citation(
         'Tzourio-Mazoyer, N.; Landeau, B.; Papathanassiou, D.; Crivello, F.; '
         'Etard, O.; Delcroix, N.; Mazoyer, B. & Joliot, M. '
         'Automated Anatomical Labeling of activations in SPM using a '

--- a/mrtrix3_connectome.py
+++ b/mrtrix3_connectome.py
@@ -2389,30 +2389,64 @@ def run_participant(bids_dir, session, shared,
         if shared.template_registration_software == 'ants':
 
             # Use ANTs SyN for registration to template
-            # From Klein et al., NeuroImage 2009:
-            run.command('ANTS 3 '
-                        + '-m PR['
+            # From Klein and Avants, Frontiers in Neuroinformatics 2013:
+            ants_prefix = 'template_to_t1'
+            run.command('ANTSRegistration'
+                        + ' --dimensionality 3'
+                        + ' --output '
+                        + ants_prefix
+                        + '.nii'
+                        + ' --use-histogram-matching 1'
+                        + ' --initial-moving-transform ['
+                        + T1_histmatched_path
+                        + ','
                         + shared.template_image_path
-                        + ', '
+                        + ',1]'
+                        + ' --transform Rigid[0.1]'
+                        + ' --metric MI['
                         + T1_histmatched_path
-                        + ', 1, 2]'
-                        + ' -o ANTS'
-                        + ' -r Gauss[2,0]'
-                        + ' -t SyN[0.5]'
-                        + ' -i 30x99x11'
-                        + ' --use-Histogram-Matching')
+                        + ','
+                        + shared.template_iamge_path
+                        + ',1,32,Regular,0.25]'
+                        + ' --convergence 1000x500x250x100'
+                        + ' --smoothing-sigmas 3x2x1x0'
+                        + ' --shrink-factors 8x4x2x1'
+                        + ' --transform Affine[0.1]'
+                        + ' --metric MI['
+                        + T1_histmatched_path
+                        + ','
+                        + shared.template_image_path
+                        + ',1,32,Regular,0.25]'
+                        + ' --convergence 1000x500x250x100'
+                        + ' --smoothing-sigmas 3x2x1x0'
+                        + ' --shrink-factors 8x4x2x1'
+                        + ' --transform BSplineSyN[0.1,26,0,3]'
+                        + ' --metric CC['
+                        + T1_histmatched_path
+                        + ','
+                        + shared.template_iamge_path
+                        + ',1,4]'
+                        + ' --convergence 100x70x50x20'
+                        + ' --smoothing-sigmas 3x2x1x0'
+                        + ' --shrink-factors 6x4x2x1')
             transformed_atlas_path = 'atlas_transformed.nii'
-            run.command('WarpImageMultiTransform 3 '
+            run.command('antsApplyTransforms'
+                        + ' --dimensionality 3'
+                        + ' --input '
                         + shared.parc_image_path
-                        + ' '
-                        + transformed_atlas_path
-                        + ' -R '
+                        + ' --reference-image '
                         + T1_histmatched_path
-                        + ' -i ANTSAffine.txt ANTSInverseWarp.nii'
-                        + ' --use-NN')
-            app.cleanup(glob.glob('ANTSWarp.nii*'))
-            app.cleanup(glob.glob('ANTSInverseWarp.nii*'))
-            app.cleanup('ANTSAffine.txt')
+                        + ' --output '
+                        + transformed_atlas_path
+                        + ' --n NearestNeighbor'
+                        + ' --transform '
+                        + ants_prefix
+                        + '1Warp.nii.gz'
+                        + ' --transform '
+                        + ants_prefix
+                        + '0GenericAffine.mat'
+                        + ' --default-value 0')
+            app.cleanup(glob.glob(ants_prefix))
 
         elif shared.template_registration_software == 'fsl':
 


### PR DESCRIPTION
Was getting incomplete coverage of the brain from the transformed parcellation image following the `WarpImageMultiTransform` command; so have updated the T1 - MNI registration to use the ANTs function calls as suggested in:

Tustison, N.; Avants, B. Explicit B-spline regularization in diffeomorphic image registration. Frontiers in Neuroinformatics, 2013, 7, 39