### PR TITLE
Recipes: Updated paths for AAL atlases

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,9 +76,9 @@ RUN apt-get remove -y libegl1-mesa-dev && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Download additional data for neuroimaging software, e.g. templates / atlases
-RUN wget -qO- http://www.gin.cnrs.fr/AAL_files/aal_for_SPM12.tar.gz | \
+RUN wget -qO- http://www.gin.cnrs.fr/wp-content/uploads/aal_for_SPM8.zip | \
     tar zx -C /opt && \
-    wget -qO- http://www.gin.cnrs.fr/AAL2_files/aal2_for_SPM12.tar.gz | \
+    wget -qO- http://www.gin.cnrs.fr/wp-content/uploads/aal2_for_SPM12.tar.gz | \
     tar zx -C /opt
 #RUN wget -q http://www.nitrc.org/frs/download.php/4499/sri24_anatomy_nifti.zip -O sri24_anatomy_nifti.zip && \
 #    unzip -qq -o sri24_anatomy_nifti.zip -d /opt/ && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,8 +76,9 @@ RUN apt-get remove -y libegl1-mesa-dev && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Download additional data for neuroimaging software, e.g. templates / atlases
-RUN wget -qO- http://www.gin.cnrs.fr/wp-content/uploads/aal_for_SPM8.zip | \
-    tar zx -C /opt && \
+RUN wget -q https://object.cscs.ch/v1/AUTH_4791e0a3b3de43e2840fe46d9dc2b334/ext-d000035_AAL1Atlas_pub/Release2018_SPM12/aal_for_SPM12.zip && \
+    unzip aal_for_SPM12.zip -d /opt && \
+    rm -f aal_for_SPM12.zip && \
     wget -qO- http://www.gin.cnrs.fr/wp-content/uploads/aal2_for_SPM12.tar.gz | \
     tar zx -C /opt
 #RUN wget -q http://www.nitrc.org/frs/download.php/4499/sri24_anatomy_nifti.zip -O sri24_anatomy_nifti.zip && \

--- a/Singularity
+++ b/Singularity
@@ -88,8 +88,8 @@ MAINTAINER Robert E. Smith <robert.smith@florey.edu.au>
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Download additional data for neuroimaging software, e.g. templates / atlases
-    wget -qO- http://www.gin.cnrs.fr/AAL_files/aal_for_SPM12.tar.gz | tar zx -C /opt
-    wget -qO- http://www.gin.cnrs.fr/AAL2_files/aal2_for_SPM12.tar.gz | tar zx -C /opt
+    wget -qO- http://www.gin.cnrs.fr/wp-content/uploads/aal_for_SPM8.zip | tar zx -C /opt
+    wget -qO- http://www.gin.cnrs.fr/wp-content/uploads/aal2_for_SPM12.tar.gz | tar zx -C /opt
     wget -q https://github.com/AlistairPerry/CCA/raw/master/parcellations/512inMNI.nii -O /opt/512inMNI.nii
     wget -qO- http://www.nitrc.org/frs/download.php/5906/ADHD200_parcellations.tar.gz | tar zx -C /opt
     wget -q "https://s3-eu-west-1.amazonaws.com/pfigshare-u-files/5528816/lh.HCPMMP1.annot" -O /opt/freesurfer/subjects/fsaverage/label/lh.HCPMMP1.annot

--- a/Singularity
+++ b/Singularity
@@ -88,7 +88,7 @@ MAINTAINER Robert E. Smith <robert.smith@florey.edu.au>
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Download additional data for neuroimaging software, e.g. templates / atlases
-    wget -qO- http://www.gin.cnrs.fr/wp-content/uploads/aal_for_SPM8.zip | tar zx -C /opt
+    wget -q https://object.cscs.ch/v1/AUTH_4791e0a3b3de43e2840fe46d9dc2b334/ext-d000035_AAL1Atlas_pub/Release2018_SPM12/aal_for_SPM12.zip && unzip aal_for_SPM12.zip -d /opt && rm -f aal_for_SPM12.zip
     wget -qO- http://www.gin.cnrs.fr/wp-content/uploads/aal2_for_SPM12.tar.gz | tar zx -C /opt
     wget -q https://github.com/AlistairPerry/CCA/raw/master/parcellations/512inMNI.nii -O /opt/512inMNI.nii
     wget -qO- http://www.nitrc.org/frs/download.php/5906/ADHD200_parcellations.tar.gz | tar zx -C /opt


### PR DESCRIPTION
Appears that web hosted paths for AAL atlas downloads have been changed, resulting in merge of #92 (intended tag `0.5.1`) failing to build.