### PR TITLE
Fix search for fsl_anat executable

### DIFF
--- a/mrtrix3_connectome.py
+++ b/mrtrix3_connectome.py
@@ -37,7 +37,7 @@ DWIBIASCORRECT_MAX_ITERS = 2
 class T1wShared(object): #pylint: disable=useless-object-inheritance
     def __init__(self):
         try:
-            self.fsl_anat_cmd = fsl.exe_name(find_executable('fsl_anat'))
+            self.fsl_anat_cmd = find_executable(fsl.exe_name('fsl_anat'))
         except MRtrixError:
             self.fsl_anat_cmd = None
         if find_executable('ROBEX'):


### PR DESCRIPTION
If `fsl_anat` was not in Path, on some Python platforms it would attempt a redundant executable search on None, which would result in an unhandled `Exception`.